### PR TITLE
Fix: Add scrolling option to side bar when browser windsor is shrunk

### DIFF
--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -65,6 +65,8 @@ const SidebarContainer = styled.div`
   border-top: 1px solid #154c79;
   max-width: 260px;
   margin-top: 60px;
+  overflow: auto;
+
 
   > hr {
     margin-top: 10px;


### PR DESCRIPTION
User is now able to scroll down to see all the channels in the sidebar